### PR TITLE
"Contributors" link Fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A repository for custom React Hooks.
   - [Git & Github](#git-and-github)
   - [React (Typescript)](#react-typescript)
 - [How to contribute?](#how-to-contribute)
-- [Contributors](#contributors)
+- [Contributors](#our-awesome-contributors)
 
 ## What is useReactHooks
 


### PR DESCRIPTION
## What was the issue ?
In the Readme

The heading Contributors does not redirect to Our Awesome Contributors, perhaps the link is incorrect.

## What this PR do?
This PR changes the link which will the user get redirected to ,to our-awesome-contributors and fixes #12 